### PR TITLE
V2.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Moved GitHub repository from `SerhiiCho/php-revival` to `php-revival/php-revival`
 - Moved GitHub repository from `SerhiiCho/php-revival-api` to `php-revival/api`
+- Fixed styles for the home page action buttons for the Chrome browser
 
 ----
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Moved GitHub repository from `SerhiiCho/php-revival` to `php-revival/php-revival`
 - Moved GitHub repository from `SerhiiCho/php-revival-api` to `php-revival/api`
 - Fixed styles for the home page action buttons for the Chrome browser
+- Fixed label styles issue on PHP 8.3 page. It was not visible on the Chrome browser
 
 ----
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Release Notes
 
+## v2.3.0 (2024-01-04)
+
+
+----
+
 ## v2.2.9 (2024-01-03)
 
 - Added 5 more random videos to a home page sidebar

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## v2.3.0 (2024-01-04)
 
+- Moved GitHub repository from `SerhiiCho/php-revival` to `php-revival/php-revival`
+- Moved GitHub repository from `SerhiiCho/php-revival-api` to `php-revival/api`
 
 ----
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-![PHP Revival](https://raw.githubusercontent.com/SerhiiCho/php-revival/master/art/php-revival-promo-big.png)
+![PHP Revival](https://raw.githubusercontent.com/php-revival/php-revival/main/art/php-revival-promo-big.png)
 
 Browser extension that every PHP developer must have. It changes styles on [php.net](https://www.php.net) website for a better experience of using php documentation. Extension adds the dark theme to php code examples, changes their color schemes and makes User Contributed Notes more readable. You'll like it.
 
@@ -15,7 +15,7 @@ Configuration file for __Laravel mix__ is called __webpack.mix.js__, it is in th
 
 **Clone the repo**
 ```bash
-git clone https://github.com/SerhiiCho/php-revival.git && cd php-revival
+git clone https://github.com/php-revival/php-revival.git && cd php-revival
 ```
 
 **Install all dependencies**

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "php-revival",
-    "version": "2.2.9",
+    "version": "2.3.0",
     "description": "Browser extension for php.net site",
     "main": "main.js",
     "scripts": {

--- a/resources/sass/_php8.sass
+++ b/resources/sass/_php8.sass
@@ -23,9 +23,9 @@
 
             code
                 background-color: rgba(70, 89, 171, 0.12) !important
-                padding: 1px 6px
-                border-radius: 4px
-                color: #303030
+                padding: 1px 6px !important
+                border-radius: 4px !important
+                color: #303030 !important
 
             h2 code
                 background-color: rgba(78, 101, 197, 0.17)
@@ -41,11 +41,11 @@
 
         &__label
             z-index: 1
-            left: 86px
-            top: 11px
-            padding: 2px 15px
-            color: white
-            background-color: $main-color-lighter
+            left: 86px !important
+            top: 11px !important
+            padding: 2px 15px !important
+            color: white !important
+            background-color: $main-color-lighter !important
 
         &__arrow
             background: url(https://php-revival.github.io/api/images/icons/arrow-right.webp) scroll no-repeat center center / contain transparent !important

--- a/resources/sass/_php8.sass
+++ b/resources/sass/_php8.sass
@@ -48,7 +48,7 @@
             background-color: $main-color-lighter
 
         &__arrow
-            background: url(https://serhiicho.github.io/php-revival-api/images/icons/arrow-right.webp) scroll no-repeat center center / contain transparent !important
+            background: url(https://php-revival.github.io/api/images/icons/arrow-right.webp) scroll no-repeat center center / contain transparent !important
             height: 40px !important
             width: 34px !important
 

--- a/resources/sass/home/_hero-actions.sass
+++ b/resources/sass/home/_hero-actions.sass
@@ -7,7 +7,7 @@
             border-color: $main-color-hover
             color: white !important
             width: 100%
-            max-width: 270px
+            max-width: 300px
             position: relative
             display: flex
             justify-content: center

--- a/resources/sass/home/_social.sass
+++ b/resources/sass/home/_social.sass
@@ -32,13 +32,13 @@
                         transform: translateY(-50%)
 
     a[href="/thanks.php"]::before
-        background: url(https://serhiicho.github.io/php-revival-api/images/icons/thanks.png) no-repeat center
+        background: url(https://php-revival.github.io/api/images/icons/thanks.png) no-repeat center
 
     a[href="/cal.php"]::before
-        background: url(https://serhiicho.github.io/php-revival-api/images/icons/events.png) no-repeat center
+        background: url(https://php-revival.github.io/api/images/icons/events.png) no-repeat center
 
     a[href="/conferences"]::before
-        background: url(https://serhiicho.github.io/php-revival-api/images/icons/talk.png) no-repeat center
+        background: url(https://php-revival.github.io/api/images/icons/talk.png) no-repeat center
 
     a[href="/thanks.php"],
     a[href="/cal.php"],

--- a/resources/ts/conf.ts
+++ b/resources/ts/conf.ts
@@ -13,7 +13,7 @@ const config = {
         },
     },
     urls: {
-        server: 'https://serhiicho.github.io/php-revival-api/',
+        server: 'https://php-revival.github.io/api/',
         randomVideos: 'random-videos.json',
     },
     homeLinks: [

--- a/src/manifest-v2.json
+++ b/src/manifest-v2.json
@@ -1,12 +1,9 @@
 {
-    "manifest_version": 3,
+    "manifest_version": 2,
     "name": "PHP Revival",
     "version": "2.3.0",
     "web_accessible_resources": [
-        {
-            "resources": ["main.css", "main.js", "images/*", "background.js"],
-            "matches": ["*://www.php.net/*", "*://php.net/*"]
-        }
+        "images/*"
     ],
     "description": "Extension that every PHP developer must have. Changes styles on php.net for a better experience of using documentation",
     "icons": {
@@ -15,7 +12,7 @@
         "64": "images/icon-64.png",
         "128": "images/icon-128.png"
     },
-    "action": {
+    "browser_action": {
 		"default_icon": "images/icon-48.png",
 		"default_title": "PHP revival"
     },
@@ -31,6 +28,6 @@
         }
     ],
     "background": {
-        "service_worker": "background.js"
+        "scripts": ["background.js"]
     }
 }

--- a/src/manifest-v3.json
+++ b/src/manifest-v3.json
@@ -1,7 +1,7 @@
 {
     "manifest_version": 3,
     "name": "PHP Revival",
-    "version": "2.2.9",
+    "version": "2.3.0",
     "web_accessible_resources": [
         {
             "resources": ["main.css", "main.js", "images/*", "background.js"],

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -1,7 +1,7 @@
 {
     "manifest_version": 2,
     "name": "PHP Revival",
-    "version": "2.2.9",
+    "version": "2.3.0",
     "web_accessible_resources": [
         "images/*"
     ],

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -1,9 +1,12 @@
 {
-    "manifest_version": 2,
+    "manifest_version": 3,
     "name": "PHP Revival",
     "version": "2.3.0",
     "web_accessible_resources": [
-        "images/*"
+        {
+            "resources": ["main.css", "main.js", "images/*", "background.js"],
+            "matches": ["*://www.php.net/*", "*://php.net/*"]
+        }
     ],
     "description": "Extension that every PHP developer must have. Changes styles on php.net for a better experience of using documentation",
     "icons": {
@@ -12,7 +15,7 @@
         "64": "images/icon-64.png",
         "128": "images/icon-128.png"
     },
-    "browser_action": {
+    "action": {
 		"default_icon": "images/icon-48.png",
 		"default_title": "PHP revival"
     },
@@ -28,6 +31,6 @@
         }
     ],
     "background": {
-        "scripts": ["background.js"]
+        "service_worker": "background.js"
     }
 }

--- a/src/readme.txt
+++ b/src/readme.txt
@@ -1,4 +1,4 @@
 All the source code, change log and installing guide
-you can find on Github https://github.com/SerhiiCho/php-revival
+you can find on Github https://github.com/php-revival/php-revival
 
 Each version has its own brach, release and tag.


### PR DESCRIPTION
- Moved GitHub repository from `SerhiiCho/php-revival` to `php-revival/php-revival`
- Moved GitHub repository from `SerhiiCho/php-revival-api` to `php-revival/api`
- Fixed styles for the home page action buttons for the Chrome browser
- Fixed label styles issue on PHP 8.3 page. It was not visible on the Chrome browser