### PR TITLE
V2.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Fixed styles for the notification banner under the navbar
 - Fixed styles for "The PHP Foundation" link on the home page's right sidebar
 - Fixed styles for the function page. Some code examples were yellow on white background and hardly visible
+- Fixed styles for news and archive pages. It now looks nicer
 
 ----
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Release Notes
 
+## v2.5.0 (2024-02-25)
+
+- Fixed styles for the notification banner under the navbar
+
+----
+
 ## v2.4.0 (2024-01-05)
 
 - Small styles fixes for search input

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## v2.5.0 (2024-02-25)
 
 - Fixed styles for the notification banner under the navbar
+- Fixed styles for "The PHP Foundation" link on the home page's right sidebar
 
 ----
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Fixed styles for the notification banner under the navbar
 - Fixed styles for "The PHP Foundation" link on the home page's right sidebar
+- Fixed styles for the function page. Some code examples were yellow on white background and hardly visible
 
 ----
 

--- a/resources/sass/_common.sass
+++ b/resources/sass/_common.sass
@@ -4,6 +4,7 @@ html
 body
     font-family: $main-font !important
     font-size: 1.1rem !important
+    margin-top: 3.25rem
 
 #toTop
     filter: invert(0.5) !important

--- a/resources/sass/_notification.sass
+++ b/resources/sass/_notification.sass
@@ -1,11 +1,11 @@
 .headsup
-    border: none
-    padding: 10px 0
-    background-color: #e9e1b5
+    border: none !important
+    padding: 10px 0 !important
+    background-color: #e9e1b5 !important
 
     a
-        color: #333
+        color: #333 !important
         border: none
         font-size: 1.1em
-        margin: 0 14px
+        margin: 0 14px !important
         border-radius: 0 0 4px 4px

--- a/resources/sass/_notification.sass
+++ b/resources/sass/_notification.sass
@@ -3,7 +3,6 @@
     padding: 10px 0 !important
     background-color: #e9e1b5 !important
     margin-top: -5px !important
-    margin-bottom: 5px !important
 
     a
         color: #333 !important

--- a/resources/sass/_notification.sass
+++ b/resources/sass/_notification.sass
@@ -3,6 +3,7 @@
     padding: 10px 0 !important
     background-color: #e9e1b5 !important
     margin-top: -5px !important
+    margin-bottom: 5px !important
 
     a
         color: #333 !important

--- a/resources/sass/_notification.sass
+++ b/resources/sass/_notification.sass
@@ -2,6 +2,7 @@
     border: none !important
     padding: 10px 0 !important
     background-color: #e9e1b5 !important
+    margin-top: -5px !important
 
     a
         color: #333 !important

--- a/resources/sass/function-page/code/_php-code.sass
+++ b/resources/sass/function-page/code/_php-code.sass
@@ -23,6 +23,10 @@
         &:before
             background: none
 
+    .examplescode
+        background: inherit !important
+        box-shadow: none !important
+
 .php8-compare,
 .example-contents
     .phpcode

--- a/resources/sass/home/_social.sass
+++ b/resources/sass/home/_social.sass
@@ -10,9 +10,10 @@
 
         .body
             margin-top: 3px
-            padding-left: 35px
 
             ul
+                padding-left: 35px
+
                 li
                     position: relative
                     background-color: transparent !important
@@ -39,6 +40,32 @@
 
     a[href="/conferences"]::before
         background: url(https://php-revival.github.io/api/images/icons/talk.png) no-repeat center
+
+    // PHP Foundation DONATE link
+    a[href="https://thephp.foundation/donate/"]
+        padding: .5rem 1.5rem .5rem 3rem
+        letter-spacing: 2px
+        background-color: $primary-color
+        border: none !important
+        text-transform: uppercase
+        position: relative
+
+        &:before
+            background: url(https://php-revival.github.io/api/images/icons/coin-light.png) no-repeat center
+            content: "" !important
+            width: 25px
+            height: 25px
+            display: inline-block
+            position: absolute
+            left: 13px
+            top: 50%
+            transform: translateY(-50%)
+            background-size: cover
+
+        &:hover
+            background-color: $primary-color !important
+            color: white !important
+            opacity: .9
 
     a[href="/thanks.php"],
     a[href="/cal.php"],

--- a/resources/sass/layout/_sidebar.sass
+++ b/resources/sass/layout/_sidebar.sass
@@ -9,6 +9,8 @@ aside.tips
     .inner
         .panel
             margin-bottom: 15px !important
+            width: 100%
+            position: inherit !important
 
             &.php-revival-panel
                 a

--- a/resources/sass/news/_cards.sass
+++ b/resources/sass/news/_cards.sass
@@ -1,6 +1,22 @@
 #layout
     section#layout-content
+        & > hr
+            display: none
+
         .newsItem
+            border-radius: 10px
+            border: 1px solid #ddd
+            margin-bottom: 25px
+            padding: 25px
+            background-color: #eaedef
+
+            &:last-child
+                margin-bottom: 0
+
+            .newsImage img
+                margin: 10px
+                border-radius: 10px
+
             header
                 .newstitle
                     margin-bottom: .5rem

--- a/src/manifest-v3.json
+++ b/src/manifest-v3.json
@@ -1,9 +1,12 @@
 {
-    "manifest_version": 2,
+    "manifest_version": 3,
     "name": "PHP Revival",
     "version": "2.4.0",
     "web_accessible_resources": [
-        "images/*"
+        {
+            "resources": ["main.css", "main.js", "images/*", "background.js"],
+            "matches": ["*://www.php.net/*", "*://php.net/*"]
+        }
     ],
     "description": "Extension that every PHP developer must have. Changes styles on php.net for a better experience of using documentation",
     "icons": {
@@ -12,7 +15,7 @@
         "64": "images/icon-64.png",
         "128": "images/icon-128.png"
     },
-    "browser_action": {
+    "action": {
 		"default_icon": "images/icon-48.png",
 		"default_title": "PHP revival"
     },
@@ -28,6 +31,6 @@
         }
     ],
     "background": {
-        "scripts": ["background.js"]
+        "service_worker": "background.js"
     }
 }

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -1,12 +1,9 @@
 {
-    "manifest_version": 3,
+    "manifest_version": 2,
     "name": "PHP Revival",
     "version": "2.4.0",
     "web_accessible_resources": [
-        {
-            "resources": ["main.css", "main.js", "images/*", "background.js"],
-            "matches": ["*://www.php.net/*", "*://php.net/*"]
-        }
+        "images/*"
     ],
     "description": "Extension that every PHP developer must have. Changes styles on php.net for a better experience of using documentation",
     "icons": {
@@ -15,7 +12,7 @@
         "64": "images/icon-64.png",
         "128": "images/icon-128.png"
     },
-    "action": {
+    "browser_action": {
 		"default_icon": "images/icon-48.png",
 		"default_title": "PHP revival"
     },
@@ -31,6 +28,6 @@
         }
     ],
     "background": {
-        "service_worker": "background.js"
+        "scripts": ["background.js"]
     }
 }


### PR DESCRIPTION
- Fixed styles for the notification banner under the navbar
- Fixed styles for "The PHP Foundation" link on the home page's right sidebar
- Fixed styles for the function page. Some code examples were yellow on white background and hardly visible
- Fixed styles for news and archive pages. It now looks nicer