### PR TITLE
V2.8.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Release Notes
 
 ## v2.8.4 (2024-09-10)
+- Fixed colors for links on the function page in the "Changelog" section. Some links was hard to see because they were yellow on the white background
 
 ## v2.8.3 (2024-08-10)
 - Fixed styles for the search field placeholder

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## v2.8.4 (2024-09-10)
 - Fixed colors for links on the function page in the "Changelog" section. Some links was hard to see because they were yellow on the white background
+- Fixed styles for the "Changelog" section on function page. The table was overflowing the container to the right
 
 ## v2.8.3 (2024-08-10)
 - Fixed styles for the search field placeholder

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Release Notes
 
-## v2.8.4 (2024-09-10)
+## v2.8.4 (2024-09-09)
 - Fixed colors for links on the function page in the "Changelog" section. Some links was hard to see because they were yellow on the white background
 - Fixed styles for the "Changelog" section on function page. The table was overflowing the container to the right
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Release Notes
 
+## v2.8.4 (2024-09-10)
+
 ## v2.8.3 (2024-08-10)
 - Fixed styles for the search field placeholder
 - Added 5 more recommended videos to the home page sidebar

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -1,9 +1,12 @@
 {
-    "manifest_version": 2,
+    "manifest_version": 3,
     "name": "PHP Revival",
     "version": "2.8.4",
     "web_accessible_resources": [
-        "images/*"
+        {
+            "resources": ["main.css", "main.js", "images/*", "background.js"],
+            "matches": ["*://www.php.net/*", "*://php.net/*"]
+        }
     ],
     "description": "Extension that every PHP developer must have. Changes styles to php.net for a better experience of using documentation",
     "icons": {
@@ -12,7 +15,7 @@
         "64": "images/icon-64.png",
         "128": "images/icon-128.png"
     },
-    "browser_action": {
+    "action": {
 		"default_icon": "images/icon-48.png",
 		"default_title": "PHP revival"
     },
@@ -28,6 +31,6 @@
         }
     ],
     "background": {
-        "scripts": ["background.js"]
+        "service_worker": "background.js"
     }
 }

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -1,7 +1,7 @@
 {
     "manifest_version": 2,
     "name": "PHP Revival",
-    "version": "2.8.3",
+    "version": "2.8.4",
     "web_accessible_resources": [
         "images/*"
     ],

--- a/extension/manifest2.json
+++ b/extension/manifest2.json
@@ -1,12 +1,9 @@
 {
-    "manifest_version": 3,
+    "manifest_version": 2,
     "name": "PHP Revival",
     "version": "2.8.4",
     "web_accessible_resources": [
-        {
-            "resources": ["main.css", "main.js", "images/*", "background.js"],
-            "matches": ["*://www.php.net/*", "*://php.net/*"]
-        }
+        "images/*"
     ],
     "description": "Extension that every PHP developer must have. Changes styles to php.net for a better experience of using documentation",
     "icons": {
@@ -15,7 +12,7 @@
         "64": "images/icon-64.png",
         "128": "images/icon-128.png"
     },
-    "action": {
+    "browser_action": {
 		"default_icon": "images/icon-48.png",
 		"default_title": "PHP revival"
     },
@@ -31,6 +28,6 @@
         }
     ],
     "background": {
-        "service_worker": "background.js"
+        "scripts": ["background.js"]
     }
 }

--- a/extension/manifest3.json
+++ b/extension/manifest3.json
@@ -1,7 +1,7 @@
 {
     "manifest_version": 3,
     "name": "PHP Revival",
-    "version": "2.8.3",
+    "version": "2.8.4",
     "web_accessible_resources": [
         {
             "resources": ["main.css", "main.js", "images/*", "background.js"],

--- a/package.json
+++ b/package.json
@@ -1,6 +1,5 @@
 {
     "name": "php-revival",
-    "version": "2.8.3",
     "description": "Browser extension for php.net site",
     "main": "main.js",
     "scripts": {

--- a/src/sass/_table-doctable.sass
+++ b/src/sass/_table-doctable.sass
@@ -3,6 +3,7 @@ table.doctable
     border-radius: 4px
     border-collapse: inherit
     box-shadow: 2px 2px 13px rgba(0, 0, 0, .1)
+    table-layout: fixed
 
     *
         border: none
@@ -25,6 +26,7 @@ table.doctable
         td
             vertical-align: middle
             padding: 8px 10px
+            word-wrap: break-word
 
             strong code
                 color: $code-red

--- a/src/sass/_table-doctable.sass
+++ b/src/sass/_table-doctable.sass
@@ -34,8 +34,9 @@ table.doctable
                 font-style: normal
                 color: $code-red
 
-            .type a
-                color: $main-color
+            a
+                color: $main-color !important
+                font-weight: bold
 
                 &:hover
                     color: darken($main-color, 7%) !important


### PR DESCRIPTION
- Fixed colors for links on the function page in the "Changelog" section. Some links was hard to see because they were yellow on the white background
- Fixed styles for the "Changelog" section on function page. The table was overflowing the container to the right