### PR TITLE
V2.8.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Release Notes
 
+## v2.8.5 (2024-09-11)
+- Fixed styles for the "Changelog" section on function page. `table-layout: fixed` wasn't a good solution for that table
+
 ## v2.8.4 (2024-09-09)
 - Fixed colors for links on the function page in the "Changelog" section. Some links was hard to see because they were yellow on the white background
 - Fixed styles for the "Changelog" section on function page. The table was overflowing the container to the right

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Release Notes
 
-## v2.8.5 (2024-09-11)
+## v2.8.5 (2024-09-10)
 - Fixed styles for the "Changelog" section on function page. `table-layout: fixed` wasn't a good solution for that table
 
 ## v2.8.4 (2024-09-09)

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -1,7 +1,7 @@
 {
     "manifest_version": 3,
     "name": "PHP Revival",
-    "version": "2.8.4",
+    "version": "2.8.5",
     "web_accessible_resources": [
         {
             "resources": ["main.css", "main.js", "images/*", "background.js"],

--- a/extension/manifest2.json
+++ b/extension/manifest2.json
@@ -1,7 +1,7 @@
 {
     "manifest_version": 2,
     "name": "PHP Revival",
-    "version": "2.8.4",
+    "version": "2.8.5",
     "web_accessible_resources": [
         "images/*"
     ],

--- a/src/sass/_table-doctable.sass
+++ b/src/sass/_table-doctable.sass
@@ -3,7 +3,7 @@ table.doctable
     border-radius: 4px
     border-collapse: inherit
     box-shadow: 2px 2px 13px rgba(0, 0, 0, .1)
-    table-layout: fixed
+    table-layout: auto
 
     *
         border: none
@@ -27,6 +27,7 @@ table.doctable
             vertical-align: middle
             padding: 8px 10px
             word-wrap: break-word
+            word-break: break-all
 
             strong code
                 color: $code-red


### PR DESCRIPTION
- Fixed styles for the "Changelog" section on function page. `table-layout: fixed` wasn't a good solution for that table